### PR TITLE
fix: Endre mapping av date til datetime i OraToSnowDescriptionMapper

### DIFF
--- a/inbound/mappers.py
+++ b/inbound/mappers.py
@@ -10,7 +10,7 @@ class OraToSnowDescriptionMapper(Mapper):
         type_mapping = {
             "<DbType DB_TYPE_NUMBER>": "number",
             "<DbType DB_TYPE_VARCHAR>": "varchar",
-            "<DbType DB_TYPE_DATE>": "date",
+            "<DbType DB_TYPE_DATE>": "datetime",  # date i oracle kan også inneholde tidspunkt
         }
         return Description(
             name=column.name,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="inbound",
-    version="0.1.0",
+    version="0.1.1",
     description=(
         "Pakke for å laste dataprodukter fra ulike kildesystemer til Snowflake"
     ),


### PR DESCRIPTION
Date kan også inneholde tidspunkt i oracle. Vi må derfor lagre informasjonen
som datetime for å være sikre på å ikke trunkere tidspunktet.
