### PR TITLE
fix: metadata load time being a constant

### DIFF
--- a/inbound/core/models.py
+++ b/inbound/core/models.py
@@ -1,5 +1,5 @@
 import datetime
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib.metadata import version
 
 
@@ -18,7 +18,7 @@ class Metadata:
     run_id: str
     job_name: str
     inbound_version: str = version("inbound")
-    load_time: datetime.datetime = datetime.datetime.now()
+    load_time: datetime.datetime = field(default_factory=datetime.datetime.now)
 
     def get_description(self):
         return [

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -253,3 +253,8 @@ class TestJob(TestCase):
             ),
         ]
         assert result == expected
+
+    def test_metadata_load_time_should_update(self):
+        meta1 = Metadata(source_env="foo", run_id="bar", job_name="baz")
+        meta2 = Metadata(source_env="foo", run_id="bar", job_name="baz")
+        assert meta1.load_time != meta2.load_time


### PR DESCRIPTION
Load time was being set as a constant on startup, which was causing the
load time to be the same for all runs.

Ref.
1: https://nav-it.slack.com/archives/C04160HE2JX/p1727570148710679
2: https://docs.python.org/3/library/dataclasses.html#dataclasses.field
