### PR TITLE
feat: use temp table when ingesting to non transient table to snowflake

### DIFF
--- a/inbound/sinks/snowflake.py
+++ b/inbound/sinks/snowflake.py
@@ -54,6 +54,16 @@ class SnowHandler:
             cur.execute(rename_new_table_query)
             cur.execute(drop_query)
 
+    def ingest_from_table(self, table: str, to_table: str):
+        query = f"insert into {to_table} select * from {table}"
+        with self.connection.cursor() as cur:
+            cur.execute(query)
+
+    def drop_table(self, table: str):
+        query = f"drop table if exists {table}"
+        with self.connection.cursor() as cur:
+            cur.execute(query)
+
 
 class FileHandler:
     def __init__(self, file_path: str = "/tmp/inbound", file_name: str = "inbound.csv"):
@@ -104,8 +114,7 @@ class SnowSink(Sink):
         column_description: list[Description],
     ):
         snow_database, snow_schema, snow_table = self.table.split(".")
-        if self.transient:
-            snow_table = f"{snow_table}__temp"
+        temp_table = f"{snow_table}__temp"
 
         if self.ddl is None:
             self.ddl = self.create_ddl(
@@ -119,7 +128,12 @@ class SnowSink(Sink):
             self.csv_writer = partial(csv.writer)
 
         self.file_handler.create_dir()
-        self.snow_handler.create_table(self.ddl)
+
+        if not self.transient:
+            self.snow_handler.create_table(self.ddl)
+        temp_table_ddl = self.ddl.replace(snow_table, temp_table)
+        self.snow_handler.drop_table(f"{snow_database}.{snow_schema}.{temp_table}")
+        self.snow_handler.create_table(temp_table_ddl)
 
         batch_results = []
         batch_counter = -1
@@ -160,7 +174,7 @@ class SnowSink(Sink):
             self.snow_handler.ingest_file_to_table(
                 database=snow_database,
                 schema=snow_schema,
-                table=snow_table,
+                table=temp_table,
                 file_path=self.file_handler.file_path,
                 file_name=self.file_handler.file_name,
             )
@@ -169,8 +183,12 @@ class SnowSink(Sink):
 
         if self.transient:
             old_table = self.table
-            new_table = f"{snow_database}.{snow_schema}.{snow_table}"
+            new_table = f"{snow_database}.{snow_schema}.{temp_table}"
             self.snow_handler.swap_tables(old_table=old_table, new_table=new_table)
+        if not self.transient:
+            temp_table = f"{snow_database}.{snow_schema}.{temp_table}"
+            self.snow_handler.ingest_from_table(table=temp_table, to_table=self.table)
+            self.snow_handler.drop_table(temp_table)
 
         return batch_results
 

--- a/inbound/sinks/snowflake.py
+++ b/inbound/sinks/snowflake.py
@@ -101,6 +101,8 @@ class SnowSink(Sink):
             self.table = f"{table}{transient_table_postfix}"
         self.transient = transient
         self.tmp_file_max_size = tmp_file_max_size
+        if csv_writer is None:
+            csv_writer = partial(csv.writer)
         self.csv_writer = csv_writer
         self.ddl = ddl
         self.snow_handler = connection_handler
@@ -124,8 +126,6 @@ class SnowSink(Sink):
                 column_descriptions=column_description,
                 transient=self.transient,
             )
-        if self.csv_writer is None:
-            self.csv_writer = partial(csv.writer)
 
         self.file_handler.create_dir()
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="inbound",
-    version="0.2.5",
+    version="0.3.0",
     description=(
         "Pakke for å laste dataprodukter fra ulike kildesystemer til Snowflake"
     ),

--- a/tests/unit/test_snow_sink.py
+++ b/tests/unit/test_snow_sink.py
@@ -16,6 +16,10 @@ class MockSnowHandler:
         file_path: str,
         file_name: str,
     ): ...
+    def ingest_from_table(self, table, to_table): ...
+    def drop_table(self, table): ...
+
+
 class MockFileHandler:
     def __init__(self, file_path: str = "/tmp/inbound", file_name: str = "inbound.csv"):
         self.file_path = file_path
@@ -28,6 +32,8 @@ class MockFileHandler:
     def create_dir(self): ...
     def close_file(self, file): ...
     def delete_file(self): ...
+
+
 def mock_generator():
     yield [(0,)]
 
@@ -99,16 +105,6 @@ class TestSnowSink(TestCase):
         assert result.strip() == expected.strip()
 
     def test_tmp_file_max_size(self):
-        class MockSnowHandler:
-            def create_table(self, ddl: str): ...
-            def ingest_file_to_table(
-                self,
-                table: str,
-                database: str,
-                schema: str,
-                file_path: str,
-                file_name: str,
-            ): ...
         class MockFileHandler:
             def __init__(
                 self, file_path: str = "/tmp/inbound", file_name: str = "inbound.csv"

--- a/tests/unit/test_snow_sink.py
+++ b/tests/unit/test_snow_sink.py
@@ -55,13 +55,11 @@ class TestSnowSink(TestCase):
             )
         ]
         result = SnowSink.create_ddl(
-            table="foo",
-            database="this",
-            schema="that",
+            table="this.that.foo",
             column_descriptions=desc,
             transient=False,
         )
-        expected = "create table if not exists this.that.foo(foo number(38, 0))"
+        expected = "create table if not exists this.that.foo (foo number(38, 0))"
         assert result.strip() == expected.strip()
 
     def test_create_ddl_varchar_should_not_have_precision_or_scale(self):
@@ -75,19 +73,17 @@ class TestSnowSink(TestCase):
             )
         ]
         result = SnowSink.create_ddl(
-            table="foo",
-            database="this",
-            schema="that",
+            table="this.that.foo",
             column_descriptions=desc,
             transient=False,
         )
-        expected = "create table if not exists this.that.foo(foo varchar)"
+        expected = "create table if not exists this.that.foo (foo varchar)"
         assert result.strip() == expected.strip()
 
     def test_create_ddl_number_with_scale(self):
         desc = [
             Description(
-                name="foo",
+                name="bar",
                 type="number",
                 precision=38,
                 scale=2,
@@ -96,12 +92,10 @@ class TestSnowSink(TestCase):
         ]
         result = SnowSink.create_ddl(
             table="foo",
-            database="this",
-            schema="that",
             column_descriptions=desc,
             transient=False,
         )
-        expected = "create table if not exists this.that.foo(foo number(38, 2))"
+        expected = "create table if not exists foo (bar number(38, 2))"
         assert result.strip() == expected.strip()
 
     def test_tmp_file_max_size(self):


### PR DESCRIPTION
- **feat: use temp table when ingesting to non transient table to snowflake**
- **refactor: initialization of csv_writer in SnowflakeSink**
- **feat!: SnowSink create_ddl method will now only take table as an argument**
- **refactor: ddl creation in SnowSink**

Jira: https://jira.adeo.no/browse/VDL-252